### PR TITLE
Address #8

### DIFF
--- a/nautobot_fsus/tables/fsu_types.py
+++ b/nautobot_fsus/tables/fsu_types.py
@@ -14,13 +14,21 @@
 #  limitations under the License.
 
 """Table definitions for FSUType models."""
+from django.conf import settings
 from nautobot.apps.tables import ButtonsColumn, TagColumn
 
 from nautobot_fsus import models
-from nautobot_fsus.tables.mixins import (
-    FSUTypeModelTable,
-    KludgeLinkedCountColumn as LinkedCountColumn,
-)
+from nautobot_fsus.tables.mixins import FSUTypeModelTable
+
+# Only import and use the workaround when running on affected versions. This is temporary,
+# next version will remove the workaround altogether and note that Nautobot versions 2.3.0 and
+# 2.3.1 are not supported due to the bug.
+# pylint: disable=ungrouped-imports
+version = settings.VERSION.split(".")
+if int(version[-1]) <= 2:
+    from nautobot_fsus.tables.mixins import KludgeLinkedCountColumn as LinkedCountColumn
+else:
+    from nautobot.apps.tables import LinkedCountColumn  # type: ignore[no-redef]
 
 
 class CPUTypeTable(FSUTypeModelTable):


### PR DESCRIPTION
Only uses the workaround for versions 2.3.0, 2.3.1.

# What does this PR do ?

Checks the Nautobot version and only uses the workaround column class for affected versions.

# Changelog 
- Only use LinkedCountColumn workaround on affected Nautobot versions.

# Additional Information
* Closes  #8 
