### PR TITLE
Enable GraphQL queries on FSU and FSU type models.

### DIFF
--- a/nautobot_fsus/models/fsu_types.py
+++ b/nautobot_fsus/models/fsu_types.py
@@ -26,15 +26,18 @@ from nautobot.extras.utils import extras_features
 from nautobot_fsus import choices
 from nautobot_fsus.models.mixins import FSUTypeModel
 
-
-@extras_features(
+EXTRAS_FEATURES = (
     "custom_fields",
     "custom_links",
     "custom_validators",
     "export_templates",
+    "graphql",
     "relationships",
     "webhooks",
 )
+
+
+@extras_features(*EXTRAS_FEATURES)
 class CPUType(FSUTypeModel):
     """Represents a CPU component type."""
 
@@ -69,14 +72,7 @@ class CPUType(FSUTypeModel):
         verbose_name_plural = "CPU Types"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class DiskType(FSUTypeModel):
     """Represents a Disk component type."""
 
@@ -100,14 +96,7 @@ class DiskType(FSUTypeModel):
         verbose_name_plural = "Disk Types"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class FanType(FSUTypeModel):
     """Represents a Fan component type."""
 
@@ -118,14 +107,7 @@ class FanType(FSUTypeModel):
         verbose_name_plural = "Fan Types"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class GPUBaseboardType(FSUTypeModel):
     """Represents a GPU Baseboard type."""
 
@@ -142,14 +124,7 @@ class GPUBaseboardType(FSUTypeModel):
         verbose_name_plural = "GPU Baseboard Types"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class GPUType(FSUTypeModel):
     """Represents a GPU component type."""
 
@@ -160,14 +135,7 @@ class GPUType(FSUTypeModel):
         verbose_name_plural = "GPU Types"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class HBAType(FSUTypeModel):
     """Represents an HBA component type."""
 
@@ -178,14 +146,7 @@ class HBAType(FSUTypeModel):
         verbose_name_plural = "HBA Types"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class MainboardType(FSUTypeModel):
     """Represents a Mainboard component type."""
 
@@ -202,14 +163,7 @@ class MainboardType(FSUTypeModel):
         verbose_name_plural = "Mainboard Types"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class NICType(FSUTypeModel):
     """Represents a NIC component type."""
 
@@ -226,14 +180,7 @@ class NICType(FSUTypeModel):
         verbose_name_plural = "NIC Types"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class OtherFSUType(FSUTypeModel):
     """Represents a generic FSU component type."""
 
@@ -244,14 +191,7 @@ class OtherFSUType(FSUTypeModel):
         verbose_name_plural = "Other FSU Types"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class PSUType(FSUTypeModel):
     """Represents a Power Supply Unit type."""
 
@@ -281,14 +221,7 @@ class PSUType(FSUTypeModel):
         verbose_name_plural = "PSU Types"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class RAMModuleType(FSUTypeModel):
     """Represents a memory component type."""
 

--- a/nautobot_fsus/models/fsus.py
+++ b/nautobot_fsus/models/fsus.py
@@ -30,16 +30,19 @@ from nautobot.extras.utils import extras_features
 from nautobot_fsus.models.mixins import FSUModel, PCIFSUModel
 from nautobot_fsus.utilities import validate_parent_device
 
-
-@extras_features(
+EXTRAS_FEATURES = (
     "custom_fields",
     "custom_links",
     "custom_validators",
     "export_templates",
+    "graphql",
     "relationships",
     "statuses",
     "webhooks",
 )
+
+
+@extras_features(*EXTRAS_FEATURES)
 class CPU(FSUModel):
     """Represents an individual CPU component in a device or storage location."""
 
@@ -89,15 +92,7 @@ class CPU(FSUModel):
                 raise ValidationError(errors)
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "statuses",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class Disk(FSUModel):
     """Represents an individual Disk component in a device or storage location."""
 
@@ -134,15 +129,7 @@ class Disk(FSUModel):
                 raise ValidationError({"parent_hba": error.error_list}) from error
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "statuses",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class Fan(FSUModel):
     """Represents an individual Fan component in a device or storage location."""
 
@@ -160,15 +147,7 @@ class Fan(FSUModel):
         verbose_name_plural = "Fans"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "statuses",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class GPU(PCIFSUModel):
     """Represents an individual GPU component in a device or storage location."""
 
@@ -219,15 +198,7 @@ class GPU(PCIFSUModel):
                 raise ValidationError(errors)
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "statuses",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class GPUBaseboard(FSUModel):
     """Represents an individual GPU Baseboard component in a device or storage location."""
 
@@ -245,15 +216,7 @@ class GPUBaseboard(FSUModel):
         verbose_name_plural = "GPU Baseboards"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "statuses",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class HBA(PCIFSUModel):
     """Represents an individual HBA component in a device or storage location."""
 
@@ -271,15 +234,7 @@ class HBA(PCIFSUModel):
         verbose_name_plural = "HBAs"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "statuses",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class Mainboard(FSUModel):
     """Represents an individual Mainboard component in a device or storage location."""
 
@@ -297,15 +252,7 @@ class Mainboard(FSUModel):
         verbose_name_plural = "Mainboards"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "statuses",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class NIC(PCIFSUModel):
     """Represents an individual NIC component in a device or storage location."""
 
@@ -330,15 +277,7 @@ class NIC(PCIFSUModel):
         verbose_name_plural = "NICs"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "statuses",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class OtherFSU(FSUModel):
     """Represents an individual generic FSU component in a device or storage location."""
 
@@ -356,6 +295,7 @@ class OtherFSU(FSUModel):
         verbose_name_plural = "OtherFSUs"
 
 
+@extras_features(*EXTRAS_FEATURES)
 class PSU(FSUModel):
     """Represents an individual PSU component in a device or storage location."""
 
@@ -381,15 +321,7 @@ class PSU(FSUModel):
         verbose_name_plural = "PSUs"
 
 
-@extras_features(
-    "custom_fields",
-    "custom_links",
-    "custom_validators",
-    "export_templates",
-    "relationships",
-    "statuses",
-    "webhooks",
-)
+@extras_features(*EXTRAS_FEATURES)
 class RAMModule(FSUModel):
     """Represents an individual RAM module component in a device or storage location."""
 

--- a/nautobot_fsus/tests/test_graphql.py
+++ b/nautobot_fsus/tests/test_graphql.py
@@ -1,0 +1,70 @@
+#  SPDX-FileCopyrightText: Copyright (c) "2024" NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Licensed under the Apache License, Version 2.0 (the "License")
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for GraphQL queries on FSU and FSU type models."""
+
+from django.test import override_settings
+from nautobot.core.graphql import execute_query
+from nautobot.core.testing import TestCase, create_test_user
+
+from nautobot_fsus import models
+
+
+class GraphQLTestCase(TestCase):
+    """Tests for GraphQL queries."""
+
+    def setUp(self):
+        """Create a test user."""
+        self.user = create_test_user("graphql_testuser")
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_fsu_graphql(self):
+        """Test GraphQL queries on FSU models."""
+        for fsu, fsu_model in (
+            ("cpus", models.CPU),
+            ("disks", models.Disk),
+            ("fans", models.Fan),
+            ("gpus", models.GPU),
+            ("gpu_baseboards", models.GPUBaseboard),
+            ("hbas", models.HBA),
+            ("nics", models.NIC),
+            ("otherfsus", models.OtherFSU),
+            ("psus", models.PSU),
+            ("ram_modules", models.RAMModule),
+        ):
+            with self.subTest(fsu=fsu):
+                query = f"query {{ {fsu} {{ name }} }}"
+                response = execute_query(query, user=self.user)
+                self.assertEqual(len(response.data[fsu]), fsu_model.objects.count())
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=["*"])
+    def test_fsu_type_graphql(self):
+        """Test GraphQL queries on FSU type models."""
+        for fsu_type, fsu_model in (
+            ("cpu_types", models.CPUType),
+            ("disk_types", models.DiskType),
+            ("fan_types", models.FanType),
+            ("gpu_types", models.GPUType),
+            ("gpu_baseboard_types", models.GPUBaseboardType),
+            ("hba_types", models.HBAType),
+            ("nic_types", models.NICType),
+            ("other_fsu_types", models.OtherFSUType),
+            ("psu_types", models.PSUType),
+            ("ram_module_types", models.RAMModuleType),
+        ):
+            with self.subTest(fsu=fsu_type):
+                query = f"query {{ {fsu_type} {{ name }} }}"
+                response = execute_query(query, user=self.user)
+                self.assertEqual(len(response.data[fsu_type]), fsu_model.objects.count())


### PR DESCRIPTION
# What does this PR do ?

Adds FSU and FSU type models to the Nautobot GraphQL schema.

# Changelog 
- Enable GraphQL queries on FSU and FSU type models.

# Additional Information
* Related to #25 
