### PR TITLE
Add guardrails for fsu create/update form.

### DIFF
--- a/nautobot_fsus/templates/nautobot_fsus/fsu.html
+++ b/nautobot_fsus/templates/nautobot_fsus/fsu.html
@@ -6,9 +6,9 @@
     {% if object.device %}
                 <li><a href="{% url list_url  %}?device={{ object.device.name }}">{{ object.device }}</a></li>
     {% else %}
-                <li><a href="{% url list_url  %}?storage_location={{ object.storage_location.name }}">{{ object.storage_location }}</a></li>
+                <li><a href="{% url list_url  %}?location={{ object.location.name }}">{{ object.location }}</a></li>
     {% endif %}
-                <li><a href="{% url list_url  %}?type={{ object.type.model_name }}">{{ object.type }}</a></li>
+                <li><a href="{% url list_url  %}?fsu_type_id={{ object.fsu_type.id }}">{{ object.fsu_type }}</a></li>
 {% endblock extra_breadcrumbs %}
 
 {% block masthead %}

--- a/nautobot_fsus/templates/nautobot_fsus/fsu_create.html
+++ b/nautobot_fsus/templates/nautobot_fsus/fsu_create.html
@@ -1,0 +1,23 @@
+{% extends "generic/object_create.html" %}
+{% load helpers %}
+{% load form_helpers %}
+
+{% block javascript %}
+{{ block.super }}
+
+<script type="text/javascript">
+    /*
+    An FSU can have only one parent, either a Device or a Location. If the parent type is changed,
+    clear the opposite parent field and update the Status choices accordingly.
+    */
+    $('#id_device').on('select2:select', function() {
+        $('#id_location').val(null).trigger('change').trigger('select2:unselect');
+        $('#id_status').val(null).trigger('change').trigger('select2:unselect').attr('data-query-param-name__n', '["Available"]');
+    });
+
+    $('#id_location').on('select2:select', function() {
+        $('#id_device').val(null).trigger('change').trigger('select2:unselect');
+        $('#id_status').val(null).trigger('change').trigger('select2:unselect').attr('data-query-param-name__n', '["Active"]');
+    });
+</script>
+{% endblock javascript %}

--- a/nautobot_fsus/views/mixins.py
+++ b/nautobot_fsus/views/mixins.py
@@ -79,6 +79,9 @@ class FSUModelViewSet(NautobotUIViewSet):
         if self.action == "retrieve":
             return "nautobot_fsus/fsu.html"
 
+        if self.action in ["create", "update"]:
+            return "nautobot_fsus/fsu_create.html"
+
         try:
             template_name = f"nautobot_fsus/fsu_{self.action}.html"
             select_template([template_name])


### PR DESCRIPTION
Selecting a device clears the location, and vice versa.

Update the Status field filter based on the parent type, Device or Location.

Fix the breadcrumbs in the FSU detail template.

# Additional Information
* Related to #26 
