### PR TITLE
Set version and update release notes for v1.0.3

### DIFF
--- a/docs/admin/release_notes/version_1.0.md
+++ b/docs/admin/release_notes/version_1.0.md
@@ -1,5 +1,15 @@
 # v1.0 Release Notes
 
+## [1.0.3 (2024-12-05)](https://github.com/NVIDIA/nautobot-app-fsus/releases/tag/v1.0.3)
+
+### Fix
+
+- FSUs and FSU types are now available in GraphQL queries ([#25](https://github.com/NVIDIA/nautobot-app-fsus/issues/25)).
+- Add form guardrails for the parent device or location selection when editing or creating an FSU ([#26](https://github.com/NVIDIA/nautobot-app-fsus/issues/26)).
+  - Changing the selected parent type will clear the other field, if set.
+  - Status field options are updated based on the parent type, Active only valid when parent is a Device, Available only valid when parent is a Location.
+- Fixed the breadcrumb display in the FSU model detail template.
+
 ## [1.0.2 (2024-10-11)](https://github.com/NVIDIA/nautobot-app-fsus/releases/tag/v1.0.2)
 
 ### Housekeeping

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-fsus"
-version = "1.0.3a0"
+version = "1.0.3"
 description = "Field Serviceable Units for Nautobot"
 authors = ["Mark Troyer <mtroyer@nvidia.com>"]
 maintainers = ["Mark Troyer <mtroyer@nvidia.com>"]


### PR DESCRIPTION
### Fix

- FSUs and FSU types are now available in GraphQL queries (#25).
- Add form guardrails for the parent device or location selection when editing or creating an FSU (#26).
  - Changing the selected parent type will clear the other field, if set.
  - Status field options are updated based on the parent type, Active only valid when parent is a Device, Available only valid when parent is a Location.
- Fixed the breadcrumb display in the FSU model detail template.

